### PR TITLE
:closed_lock_with_key: API 엔드포인트 숨김 처리

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,14 @@ const nextConfig = {
 
     return config
   },
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: `${process.env.NEXT_PUBLIC_SERVER_URL}/api/:path*`,
+      },
+    ]
+  },
 }
 
 module.exports = nextConfig

--- a/src/envs/index.ts
+++ b/src/envs/index.ts
@@ -1,6 +1,7 @@
 export const NAVER_MAPS_APP = process.env.NEXT_PUBLIC_NAVER_MAPS_APP
 export const NAVER_MAPS_CLIENT_ID = process.env.NEXT_PUBLIC_NAVER_MAPS_CLIENT_ID
 export const NAVER_MAPS_CLIENT_SECRET = process.env.NEXT_PUBLIC_NAVER_MAPS_CLIENT_SECRET
+export const SERVER_URL = process.env.NEXT_PUBLIC_SERVER_URL
 
 export type AppEnv = 'production' | 'development'
 
@@ -9,10 +10,10 @@ const getAppEnv = (): AppEnv => (process.env.NEXT_PUBLIC_APP_ENV as Exclude<AppE
 export const getApiEndpoint = () => {
   switch (getAppEnv()) {
     case 'production':
-      return 'https://memory-trip.herokuapp.com'
+      return SERVER_URL
     case 'development':
-      return 'https://memory-trip.herokuapp.com'
+      return SERVER_URL
     default:
-      return 'https://memory-trip.herokuapp.com'
+      return SERVER_URL
   }
 }

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -1,11 +1,9 @@
 import axios, { type AxiosRequestConfig } from 'axios'
 
-import { getApiEndpoint } from '@/envs'
 import type { ServerResponse } from '@/types/api'
 
 const createApi = () => {
   const _api = axios.create({
-    baseURL: getApiEndpoint(),
     withCredentials: true,
   })
 


### PR DESCRIPTION
## Why need this change?
- #16 이슈에 따라 env 및 rewrites 적용

## Key Changes
- .env.local에 NEXT_PUBLIC_SERVER_URL 추가함.
- rewrites 적용하여 네트워크 탭에 API 엔드포인트 노출되지 않도록 수정함.

## To Reviewers
- 변경된 env 파일 따로 공유드릴게욤

## ScreenShot
-

## Reference
- https://nextjs.org/docs/pages/api-reference/next-config-js/rewrites
