### PR TITLE
:sparkles: add login route handler for cookie

### DIFF
--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -1,0 +1,42 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+import { SERVER_URL } from '@/envs'
+
+interface LoginResult {
+  data: {
+    token: string
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const { email, password } = await request.json()
+
+  const response = await fetch(`${SERVER_URL}/api/login`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      email,
+      password,
+    }),
+  })
+
+  const loginResult: LoginResult = await response.json()
+
+  const nextResponse = NextResponse.json({ res: loginResult }, { status: 200 })
+
+  const expirationDate = new Date()
+  expirationDate.setDate(expirationDate.getDate() + 1)
+
+  nextResponse.cookies.set({
+    name: 'accessToken',
+    value: loginResult.data.token,
+    httpOnly: true,
+    expires: expirationDate,
+    secure: true,
+    sameSite: 'strict',
+  })
+
+  return nextResponse
+}


### PR DESCRIPTION
## Why need this change?
- Server Component에서 accessToken에 접근하기 위해 route handler에서 cookie에 토큰을 저장해둠.

## Key Changes
- login route handler 추가

## To Reviewers
-

## ScreenShot
-

## Reference
- https://nextjs.org/docs/app/building-your-application/routing/router-handlers
- https://codethenporrada.xyz/how-to-set-a-cookie-using-nextjs-13-api-routes
