### PR TITLE
:recycle: zod 타입 검증 추가 및 mutation 타입 에러 해결

### DIFF
--- a/src/components/views/login/LoginView.tsx
+++ b/src/components/views/login/LoginView.tsx
@@ -25,9 +25,7 @@ const LoginView = () => {
 
   const onSubmit = async ({ email, password }: FormValues) => {
     try {
-      const {
-        data: { token },
-      } = await signIn(email, password)
+      const { token } = await signIn({ email, password })
       setAccessTokenToCookie(token)
       toast.success('로그인에 성공했어요.')
       push(ROUTE.MAIN)

--- a/src/components/views/planDetail/PlanDetailView.tsx
+++ b/src/components/views/planDetail/PlanDetailView.tsx
@@ -18,10 +18,10 @@ const PlanDetailView = () => {
   const { query } = useRouter()
   const planId = Number(query.slug)
 
-  const timelinesObjectQuery = useQuery(QueryKeys.TIMELINES(planId), () => getTimelines(planId), {
+  const timelinesObjectQuery = useQuery(QueryKeys.TIMELINES(planId), () => getTimelines({ planId }), {
     enabled: !!query.slug,
   })
-  const planQuery = useQuery(QueryKeys.PLAN(planId), () => getPlan(planId), {
+  const planQuery = useQuery(QueryKeys.PLAN(planId), () => getPlan({ planId }), {
     enabled: !!query.slug,
   })
 
@@ -29,8 +29,8 @@ const PlanDetailView = () => {
     return null
   }
 
-  const { data: timelinesObject } = timelinesObjectQuery.data
-  const { data: plan } = planQuery.data
+  const timelinesObject = timelinesObjectQuery.data
+  const plan = planQuery.data
 
   const datesArray = getDatesArray(plan.startDate, plan.endDate)
 

--- a/src/components/views/planDetail/components/TimelineBlock.tsx
+++ b/src/components/views/planDetail/components/TimelineBlock.tsx
@@ -101,7 +101,7 @@ const TimeLineBlock = ({ date, timelines, planId, day }: TimeLineBlockProps) => 
           isEditing && selectedLocations.length > 0 ? 'flex gap-2' : 'hidden',
           'fixed bottom-0 left-0 flex h-16 w-full items-center justify-center bg-blue-500 text-base font-bold text-white'
         )}
-        onClick={() => deleteTimelinesMutation.mutate(selectedLocations)}
+        onClick={() => deleteTimelinesMutation.mutate({ ids: selectedLocations })}
         type='submit'
       >
         <i className='ri-delete-bin-line' />

--- a/src/components/views/planDetail/hooks/useDeleteTimelinesMutation.ts
+++ b/src/components/views/planDetail/hooks/useDeleteTimelinesMutation.ts
@@ -2,16 +2,20 @@ import { type UseMutationOptions, useMutation, useQueryClient } from '@tanstack/
 
 import { deleteTimelines } from '@/lib/apis/timeline'
 import { QueryKeys } from '@/lib/queryKeys'
+import { type ServerResponse } from '@/types/api'
+import { type DeleteTimelinesParams } from '@/types/timeline'
 
-const useDeleteTimelinesMutation = (planId: number, options?: UseMutationOptions) => {
+const useDeleteTimelinesMutation = (
+  planId: number,
+  options?: UseMutationOptions<ServerResponse<unknown>, unknown, DeleteTimelinesParams>
+) => {
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: deleteTimelines,
     onSuccess: (data, variables, context) => {
-      // @ts-expect-error FIXME: Argument of type 'string[]' is not assignable to parameter of type 'void'.
       options?.onSuccess && options.onSuccess(data, variables, context)
-      return queryClient.invalidateQueries(QueryKeys.PLAN(planId))
+      return queryClient.invalidateQueries(QueryKeys.TIMELINES(planId))
     },
   })
 }

--- a/src/components/views/search/hooks/useCreateTimelinesMutation.ts
+++ b/src/components/views/search/hooks/useCreateTimelinesMutation.ts
@@ -2,14 +2,18 @@ import { type UseMutationOptions, useMutation, useQueryClient } from '@tanstack/
 
 import { createTimelines } from '@/lib/apis/timeline'
 import { QueryKeys } from '@/lib/queryKeys'
+import { type ServerResponse } from '@/types/api'
+import { type CreateTimelinesParams } from '@/types/timeline'
 
-const useCreateTimelinesMutation = (planId: number, options: UseMutationOptions) => {
+const useCreateTimelinesMutation = (
+  planId: number,
+  options: UseMutationOptions<ServerResponse<unknown>, unknown, CreateTimelinesParams>
+) => {
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: createTimelines,
     onSuccess: (data, variables, context) => {
-      // @ts-expect-error FIXME: Argument of type 'string[]' is not assignable to parameter of type 'void'.
       options?.onSuccess && options.onSuccess(data, variables, context)
 
       return queryClient.invalidateQueries(QueryKeys.PLAN(planId))

--- a/src/components/views/signup/components/EmailVerification.tsx
+++ b/src/components/views/signup/components/EmailVerification.tsx
@@ -41,8 +41,8 @@ const EmailVerification = () => {
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     try {
-      await verifyCode(getValues('email'), codes.join(''))
-      await signUp(getValues('email'), getValues('password'), getValues('nickname'))
+      await verifyCode({ email: getValues('email'), code: codes.join('') })
+      await signUp({ email: getValues('email'), password: getValues('password'), nickname: getValues('nickname') })
       toast.success('회원가입이 완료되었어요.')
       push(ROUTE.SIGN_IN)
     } catch (error) {

--- a/src/components/views/signup/components/SignUpForm.tsx
+++ b/src/components/views/signup/components/SignUpForm.tsx
@@ -32,7 +32,7 @@ const SignUpForm = ({ setStep }: Props) => {
 
   const onSubmit = async ({ email }: FormValues) => {
     try {
-      await sendCode(email)
+      await sendCode({ email })
       setStep(STEP.EMAIL_VERIFICATION)
     } catch (error) {
       onError(error)

--- a/src/components/views/signup/hooks/useEmailValidation.ts
+++ b/src/components/views/signup/hooks/useEmailValidation.ts
@@ -17,7 +17,7 @@ export const useEmailValidation = (email: string) => {
     const validateEmail = async () => {
       try {
         setIsEmailValidating(true)
-        await checkDuplicateEmail(email)
+        await checkDuplicateEmail({ email })
         setIsDuplicated(false)
       } catch (error) {
         if (isServerErrorWithMessage(error)) {

--- a/src/hooks/useAxiosInterceptor.ts
+++ b/src/hooks/useAxiosInterceptor.ts
@@ -2,14 +2,11 @@ import { useEffect } from 'react'
 
 import type { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 
-import { ACCESS_TOKEN, getAccessTokenFromCookie } from '@/features/auth/token'
 import { axiosInstance } from '@/lib/apis'
 import type { RegenerateAccessTokenByRefreshTokenResponse, ServerError } from '@/types/api'
 
 export const useAxiosInterceptor = () => {
   const requestHandler = (config: InternalAxiosRequestConfig) => {
-    config.headers.Cookie = `${ACCESS_TOKEN}=${getAccessTokenFromCookie() ?? ''}`
-
     return config
   }
 

--- a/src/lib/apis/auth.ts
+++ b/src/lib/apis/auth.ts
@@ -1,20 +1,40 @@
 import api from '@/lib/apis'
+import {
+  type VerifyCodeParams,
+  type SendCodeParams,
+  type SingUpParams,
+  type CheckDuplicateEmailParams,
+  type CheckDuplicateEmail,
+  CheckDuplicateEmailSchema,
+  type SignInParams,
+  type SignIn,
+  SignInSchema,
+} from '@/types/auth'
 
-export const signUp = (email: string, password: string, nickname: string) =>
-  api.post('/api/signup', {
+export const signUp = ({ email, password, nickname }: SingUpParams) => {
+  return api.post('/api/signup', {
     email,
     password,
     nickname,
   })
+}
 
-export const sendCode = (email: string) => api.get(`/api/mail/sendCode?rcv=${email}`)
+export const sendCode = ({ email }: SendCodeParams) => {
+  return api.get(`/api/mail/sendCode?rcv=${email}`)
+}
 
-export const verifyCode = (email: string, code: string) => api.get(`/api/mail/verifyCode?rcv=${email}&code=${code}`)
+export const verifyCode = ({ email, code }: VerifyCodeParams) =>
+  api.get(`/api/mail/verifyCode?rcv=${email}&code=${code}`)
 
-export const checkDuplicateEmail = (email: string) => api.get<boolean>(`/api/checkEmail?email=${email}`)
+export const checkDuplicateEmail = async ({ email }: CheckDuplicateEmailParams) => {
+  const response = await api.get<CheckDuplicateEmail>(`/api/checkEmail?email=${email}`)
+  return CheckDuplicateEmailSchema.parse(response.data)
+}
 
-export const signIn = (email: string, password: string) =>
-  api.post<{ token: string }>('/api/login', {
+export const signIn = async ({ email, password }: SignInParams) => {
+  const response = await api.post<SignIn>('/api/login', {
     email,
     password,
   })
+  return SignInSchema.parse(response.data)
+}

--- a/src/lib/apis/plan.ts
+++ b/src/lib/apis/plan.ts
@@ -1,6 +1,7 @@
 import api from '@/lib/apis'
-import { type Plan } from '@/types/plan'
+import { PlanSchema, type Plan, type GetPlanParams } from '@/types/plan'
 
-export const getPlan = async (planId: number) => {
-  return api.get<Plan>(`api/plans/${planId}`)
+export const getPlan = async ({ planId }: GetPlanParams) => {
+  const response = await api.get<Plan>(`api/plans/${planId}`)
+  return PlanSchema.parse(response.data)
 }

--- a/src/lib/apis/timeline.ts
+++ b/src/lib/apis/timeline.ts
@@ -1,12 +1,20 @@
 import { TIMELINE_TYPE } from '@/constants/timelineType'
 import api from '@/lib/apis'
-import { type Timeline } from '@/types/timeline'
+import {
+  type TimelinesObject,
+  type Timeline,
+  type CreateTimelinesParams,
+  TimelinesObjectSchema,
+  type GetTimelinesParams,
+  type DeleteTimelinesParams,
+} from '@/types/timeline'
 
-export const getTimelines = async (planId: number) => {
-  return api.get<Record<string, Timeline[]>>(`api/timelines?planId=${planId}`)
+export const getTimelines = async ({ planId }: GetTimelinesParams) => {
+  const response = await api.get<TimelinesObject>(`api/timelines?planId=${planId}`)
+  return TimelinesObjectSchema.parse(response.data)
 }
 
-export const createTimelines = ({ locations, planId, date }: { locations: string[]; planId: number; date: string }) => {
+export const createTimelines = ({ locations, planId, date }: CreateTimelinesParams) => {
   const timelines: Array<{
     type: Timeline['type']
     date: Timeline['date']
@@ -29,6 +37,6 @@ export const createTimelines = ({ locations, planId, date }: { locations: string
   return api.post('/api/timelines', timelines)
 }
 
-export const deleteTimelines = (ids: string[]) => {
+export const deleteTimelines = ({ ids }: DeleteTimelinesParams) => {
   return api.delete(`/api/timelines?ids=${ids.join(',')}`)
 }

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -7,7 +7,7 @@ export const isServerErrorWithMessage = (error: unknown): error is AxiosError<Se
     error instanceof AxiosError &&
     error.response !== undefined &&
     typeof error.response.data === 'object' &&
-    'responseMessage' in error.response?.data &&
+    'responseMessage' in error.response.data &&
     typeof (error.response.data as Record<string, unknown>).responseMessage === 'string'
   )
 }

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod'
+
+export interface SingUpParams {
+  email: string
+  password: string
+  nickname: string
+}
+
+export interface SendCodeParams {
+  email: string
+}
+
+export interface VerifyCodeParams {
+  email: string
+  code: string
+}
+
+export interface CheckDuplicateEmailParams {
+  email: string
+}
+
+export const CheckDuplicateEmailSchema = z.boolean()
+
+export type CheckDuplicateEmail = z.infer<typeof CheckDuplicateEmailSchema>
+
+export interface SignInParams {
+  email: string
+  password: string
+}
+
+export const SignInSchema = z.object({
+  token: z.string(),
+})
+
+export type SignIn = z.infer<typeof SignInSchema>

--- a/src/types/plan.ts
+++ b/src/types/plan.ts
@@ -1,13 +1,21 @@
-export interface Plan {
-  id: number
-  userId: number
-  city: string[]
-  startDate: string
-  endDate: string
-  tripType: string
-  participants: number[]
-  createdAt: string
-  isPublic: boolean
-  views: number
-  likes: number
+import { z } from 'zod'
+
+export interface GetPlanParams {
+  planId: number
 }
+
+export const PlanSchema = z.object({
+  id: z.number(),
+  userId: z.number(),
+  city: z.array(z.string()),
+  startDate: z.string(),
+  endDate: z.string(),
+  tripType: z.string(),
+  participants: z.array(z.number()),
+  createdAt: z.string(),
+  isPublic: z.boolean(),
+  views: z.number(),
+  likes: z.number(),
+})
+
+export type Plan = z.infer<typeof PlanSchema>

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -1,6 +1,12 @@
-export type TimeLineType = 'FLIGHT' | 'PLACE' | 'MEMO'
+import { z } from 'zod'
 
-export type TimelinesObject = Record<string, Timeline[]>
+export interface GetTimelinesParams {
+  planId: number
+}
+
+export const TimeLineTypeSchema = z.union([z.literal('FLIGHT'), z.literal('PLACE'), z.literal('MEMO')])
+
+export type TimeLineType = z.infer<typeof TimeLineTypeSchema>
 
 export interface Timeline {
   id: number
@@ -10,4 +16,28 @@ export interface Timeline {
   data: string
   createdAt: string
   planId: number
+}
+
+export const TimelineSchema = z.object({
+  id: z.number(),
+  type: TimeLineTypeSchema,
+  date: z.string(),
+  memo: z.string(),
+  data: z.string(),
+  createdAt: z.string(),
+  planId: z.number(),
+})
+
+export const TimelinesObjectSchema = z.record(z.array(TimelineSchema))
+
+export type TimelinesObject = z.infer<typeof TimelinesObjectSchema>
+
+export interface CreateTimelinesParams {
+  locations: string[]
+  planId: number
+  date: string
+}
+
+export interface DeleteTimelinesParams {
+  ids: string[]
 }


### PR DESCRIPTION
## Why need this change?
- API 응답값에 zod 사용하여 타입 안전성 보완
- useCreateTimelinesMutation, useDeleteTimelinesMutation hook에서 발생했던 타입 에러 해결

## Key Changes
- zod 타입 검증 추가
```ts
// types/timeline.ts
export const TimeLineTypeSchema = z.union([z.literal('FLIGHT'), z.literal('PLACE'), z.literal('MEMO')])

export const TimelineSchema = z.object({
  id: z.number(),
  type: TimeLineTypeSchema,
  date: z.string(),
  memo: z.string(),
  data: z.string(),
  createdAt: z.string(),
  planId: z.number(),
})

export const TimelinesObjectSchema = z.record(z.array(TimelineSchema))

export type TimelinesObject = z.infer<typeof TimelinesObjectSchema>

// lib/apis/timeline.ts
export const getTimelines = async ({ planId }: GetTimelinesParams) => {
  const response = await api.get<TimelinesObject>(`api/timelines?planId=${planId}`)
  return TimelinesObjectSchema.parse(response.data)
}
```

- mutation hook 타입 에러 해결
```ts
const useDeleteTimelinesMutation = (
  planId: number,
  /* 
  파라미터로 받는 options의 타입인 UseMutationOption은 제네릭으로 선언되어 있으며,
  타입을 별도로 선언하지 않았기 때문에 디폴트 타입이 사용됩니다.
  이로 인해 useMutation의 타입 추론과 일치하지 않아서 발생하는 에러를 해결하기 위해 제네릭 타입을 명시적으로 지정해주었습니다.
  */
  options?: UseMutationOptions<ServerResponse<unknown>, unknown, DeleteTimelinesParams>
) => {
  const queryClient = useQueryClient()

  return useMutation({
    mutationFn: deleteTimelines,
    onSuccess: (data, variables, context) => {
      options?.onSuccess && options.onSuccess(data, variables, context)
      return queryClient.invalidateQueries(QueryKeys.TIMELINES(planId))
    },
  })
}
```

## To Reviewers
-

## ScreenShot
![image](https://github.com/Memorip/memorip-frontend/assets/73215539/72028a7f-784e-46e1-9779-8618d5143c28)

## Reference
- TanStack/query/packages/react-query/src/types.ts (line 86~)

```ts
export interface UseMutationOptions<
  TData = unknown,
  TError = unknown,
  TVariables = void,
  TContext = unknown,
> extends ContextOptions,
    Omit<
      MutationObserverOptions<TData, TError, TVariables, TContext>,
      '_defaulted' | 'variables'
    > {}
```
